### PR TITLE
pinv instead of pinv2

### DIFF
--- a/dirichletcal/calib/multinomial.py
+++ b/dirichletcal/calib/multinomial.py
@@ -274,7 +274,7 @@ def _newton_update(weights_0, X, XX_T, target, k, method_, maxiter=int(1024),
             updates = gradient / hessian
         else:
             try:
-                inverse = scipy.linalg.pinv2(hessian)
+                inverse = scipy.linalg.pinv(hessian)
                 updates = np.matmul(inverse, gradient)
             except (raw_np.linalg.LinAlgError, ValueError) as err:
                 logging.error(err)


### PR DESCRIPTION
"pinv2" was deprecated in scipy 1.7.0 in favor of "pinv" and removed in scipy 1.9.0

https://github.com/scipy/scipy/releases/tag/v1.9.0

![image](https://user-images.githubusercontent.com/69281238/186924889-72bc354b-6ab5-44bf-aa9d-617f6436249e.png)
